### PR TITLE
Fix/threshold : 임계치 알림 kafka 설정 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 
     // 📦 Kafka
     implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'org.apache.kafka:kafka-streams'
 
     // 🔐 JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/com/example/emergencyassistb4b4/domain/alert/kafka/config/listener/ThresholdAlertListenerConfig.java
+++ b/src/main/java/com/example/emergencyassistb4b4/domain/alert/kafka/config/listener/ThresholdAlertListenerConfig.java
@@ -2,7 +2,6 @@ package com.example.emergencyassistb4b4.domain.alert.kafka.config.listener;
 
 import com.example.emergencyassistb4b4.domain.alert.kafka.config.consumer.KafkaConsumerConfig;
 import com.example.emergencyassistb4b4.domain.alert.kafka.config.error.KafkaErrorHandlerConfig;
-import com.example.emergencyassistb4b4.global.kafka.dto.DisasterReportedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,26 +12,26 @@ import org.springframework.kafka.listener.ContainerProperties;
 
 @Configuration
 @RequiredArgsConstructor
-public class ThresholdAlertListenerConfig { // 임계값 초과 이벤트(누적 발생 수 기준) 처리용 Kafka 리스너 설정
+public class ThresholdAlertListenerConfig { // 임계치 알림 수신 전용
 
     private final KafkaConsumerConfig consumerConfig;
     private final KafkaErrorHandlerConfig errorHandlerConfig;
 
     // ConsumerFactory 설정 (DisasterReportedEvent 처리)
     @Bean
-    public ConsumerFactory<String, DisasterReportedEvent> thresholdConsumerFactory() {
+    public ConsumerFactory<String, com.example.emergencyassistb4b4.global.kafka.dto.ThresholdAlertEvent> thresholdConsumerFactory() {
 
         return new DefaultKafkaConsumerFactory<>(
-                consumerConfig.baseConsumerProps(null, DisasterReportedEvent.class.getName())
-        );
-    }
+                consumerConfig.baseConsumerProps(null, com.example.emergencyassistb4b4.global.kafka.dto.ThresholdAlertEvent.class.getName())
+                        );
+        }
 
     // 리스너 팩토리 설정
     @Bean(name = "thresholdListenerFactory")
-    public ConcurrentKafkaListenerContainerFactory<String, DisasterReportedEvent> thresholdListenerFactory() {
+    public ConcurrentKafkaListenerContainerFactory<String, com.example.emergencyassistb4b4.global.kafka.dto.ThresholdAlertEvent> thresholdListenerFactory() {
 
 
-        var factory = new ConcurrentKafkaListenerContainerFactory<String, DisasterReportedEvent>();
+        var factory = new ConcurrentKafkaListenerContainerFactory<String, com.example.emergencyassistb4b4.global.kafka.dto.ThresholdAlertEvent>();
 
         factory.setConsumerFactory(thresholdConsumerFactory());
         factory.setConcurrency(3);

--- a/src/main/java/com/example/emergencyassistb4b4/domain/alert/kafka/consumer/listener/ThresholdAlertEventListener.java
+++ b/src/main/java/com/example/emergencyassistb4b4/domain/alert/kafka/consumer/listener/ThresholdAlertEventListener.java
@@ -1,7 +1,7 @@
 package com.example.emergencyassistb4b4.domain.alert.kafka.consumer.listener;
 
 import com.example.emergencyassistb4b4.domain.alert.service.trigger.ReportThresholdAlertTriggerService;
-import com.example.emergencyassistb4b4.global.kafka.dto.DisasterReportedEvent;
+import com.example.emergencyassistb4b4.global.kafka.dto.ThresholdAlertEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -28,7 +28,7 @@ public class ThresholdAlertEventListener { // 누적 기준(예: 같은 장소�
             containerFactory = "thresholdListenerFactory"
     )
     public void onDisasterReported(
-            DisasterReportedEvent event,
+            ThresholdAlertEvent event,
             @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
             @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
             @Header(KafkaHeaders.OFFSET) long offset
@@ -38,11 +38,11 @@ public class ThresholdAlertEventListener { // 누적 기준(예: 같은 장소�
 
         try {
             // 수신된 메시지 기반으로 누적 기준 검사 및 알림 트리거
-            triggerService.checkReportThreshold(event);
+            triggerService.handleThresholdAlert(event);
         } catch (Exception e) {
             // 처리 중 예외 발생 시 로그 출력 및 예외 재전파 -> DefaultErrorHandler에 의해 retry 또는 DLQ 전송됨
             log.error("[누적 알림 처리 실패] province={}, city={}, type={}, time={}",
-                event.getProvince(), event.getCity(), event.getDisasterType(), event.getReportedAt(), e);
+                event.getProvince(), event.getCity(), event.getAlertType(), event.getWindowStart(), e);
             throw e; // DLQ로 이동하기 위해 예외를 반드시 throw 해야 함
         }
     }

--- a/src/main/java/com/example/emergencyassistb4b4/domain/alert/kafka/streams/ThresholdDetectionTopology.java
+++ b/src/main/java/com/example/emergencyassistb4b4/domain/alert/kafka/streams/ThresholdDetectionTopology.java
@@ -1,0 +1,59 @@
+package com.example.emergencyassistb4b4.domain.alert.kafka.streams;
+
+import com.example.emergencyassistb4b4.global.kafka.dto.DisasterReportedEvent;
+import com.example.emergencyassistb4b4.global.kafka.dto.ThresholdAlertEvent;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.*;
+import java.time.ZoneId;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafkaStreams;
+import org.springframework.kafka.support.serializer.JsonSerde;
+
+
+@Configuration
+@EnableKafkaStreams
+public class ThresholdDetectionTopology {
+
+    @Value("${spring.kafka.topic.immediate}")
+    private String immediateTopic;
+
+    @Value("${spring.kafka.topic.threshold}")
+    private String thresholdTopic;
+
+    @Bean
+    public KStream<String, DisasterReportedEvent> thresholdStream(StreamsBuilder builder) {
+
+        Serde<String> stringSerde = Serdes.String();
+        JsonSerde<DisasterReportedEvent> drSerde  = new JsonSerde<>(DisasterReportedEvent.class);
+        JsonSerde<ThresholdAlertEvent> alertSerde = new JsonSerde<>(ThresholdAlertEvent.class);
+
+        drSerde.deserializer().addTrustedPackages("com.example.emergencyassistb4b4.global.kafka.dto");
+        alertSerde.deserializer().addTrustedPackages("com.example.emergencyassistb4b4.global.kafka.dto");
+
+        KStream<String, DisasterReportedEvent> source =
+                builder.stream(immediateTopic, Consumed.with(stringSerde, drSerde));
+
+        source.map((k, v) -> {
+            String groupKey = v.getProvince() + ":" + v.getCity() + ":" + v.getDisasterType();
+            long reportedAtEpoch =
+                    v.getReportedAt().atZone(ZoneId.of("Asia/Seoul")).toInstant().toEpochMilli();
+
+            ThresholdAlertEvent evt = new ThresholdAlertEvent(
+                    v.getProvince(),
+                    v.getCity(),
+                    v.getDisasterType(),   // alertType 슬롯에 재난타입 유지
+                    reportedAtEpoch       // windowStart=신고 시각 → 트리거에서 '날짜'로 사용
+            );
+
+            return KeyValue.pair(groupKey, evt);
+        })
+                .to(thresholdTopic, Produced.with(stringSerde, alertSerde));
+
+        return source;
+    }
+}

--- a/src/main/java/com/example/emergencyassistb4b4/domain/alert/service/trigger/ReportThresholdAlertTriggerService.java
+++ b/src/main/java/com/example/emergencyassistb4b4/domain/alert/service/trigger/ReportThresholdAlertTriggerService.java
@@ -2,9 +2,12 @@ package com.example.emergencyassistb4b4.domain.alert.service.trigger;
 
 import com.example.emergencyassistb4b4.domain.alert.redis.RedisThresholdCounter;
 import com.example.emergencyassistb4b4.domain.alert.orchestrator.ReportThresholdAlertOrchestratorService;
-import com.example.emergencyassistb4b4.global.kafka.dto.DisasterReportedEvent;
 import java.time.Duration;
 import java.util.List;
+
+import com.example.emergencyassistb4b4.global.kafka.dto.ThresholdAlertEvent;
+import java.time.Instant;
+import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -19,7 +22,8 @@ public class ReportThresholdAlertTriggerService {
 
     private static final Duration KEY_TTL = Duration.ofDays(1);
 
-    public void checkReportThreshold(DisasterReportedEvent event) {
+    public void handleThresholdAlert(ThresholdAlertEvent event) {
+
         String counterKey = generateReportCounterKey(event);
         String notifyKeyPrefix = "alert:" + counterKey;
         List<Long> thresholds = List.of(3L, 5L, 7L, 10L);
@@ -34,11 +38,16 @@ public class ReportThresholdAlertTriggerService {
         }
     }
 
-    private String generateReportCounterKey(DisasterReportedEvent event) {
+    private String generateReportCounterKey(ThresholdAlertEvent event) {
+
+        var day = Instant.ofEpochMilli(event.getWindowStart())
+                .atZone(ZoneId.of("Asia/Seoul"))
+                .toLocalDate();
+
         return String.format("report:%s:%s:%s:%s",
             event.getProvince(),
             event.getCity(),
-            event.getDisasterType(),
-            event.getReportedAt().toLocalDate());
+            event.getAlertType(),
+            day);
     }
 }

--- a/src/main/java/com/example/emergencyassistb4b4/global/kafka/config/KafkaTopicConfig.java
+++ b/src/main/java/com/example/emergencyassistb4b4/global/kafka/config/KafkaTopicConfig.java
@@ -23,6 +23,12 @@ public class KafkaTopicConfig { // Kafka 토픽을 코드에서 직접 생성하
     @Value("${spring.kafka.topic.dlt.threshold}")
     private String thresholdDltTopic;
 
+    @Value("${spring.kafka.topic.volunteer}")
+    private String volunteerTopic;
+
+    @Value("${spring.kafka.topic.dlt.volunteer}")
+    private String volunteerDltTopic;
+
     @Value("${kafka.topic.partitions:3}")
     private int partitions;
 
@@ -58,22 +64,30 @@ public class KafkaTopicConfig { // Kafka 토픽을 코드에서 직접 생성하
             .build();
     }
 
+    // 파생(임계치) 토픽
+    @Bean
+    public NewTopic reportThreshold() {
+
+        return TopicBuilder.name(thresholdTopic).partitions(partitions).replicas(replicas).build();
+    }
+
+    @Bean
+    public NewTopic reportThresholdDLT() {
+
+        return TopicBuilder.name(thresholdDltTopic).partitions(partitions).replicas(replicas).build();
+    }
+
+   // 봉사글 토픽
     @Bean
     public NewTopic volunteerPostUpdated() {
 
-        return TopicBuilder.name(thresholdTopic)
-            .partitions(partitions)
-            .replicas(replicas)
-            .build();
+        return TopicBuilder.name(volunteerTopic).partitions(partitions).replicas(replicas).build();
     }
 
     @Bean
     public NewTopic volunteerPostUpdatedDLT() {
 
-        return TopicBuilder.name(thresholdDltTopic)
-            .partitions(partitions)
-            .replicas(replicas)
-            .build();
+        return TopicBuilder.name(volunteerDltTopic).partitions(partitions).replicas(replicas).build();
     }
 
     // 역직렬화 실패용 DLT(-deser)
@@ -86,13 +100,15 @@ public class KafkaTopicConfig { // Kafka 토픽을 코드에서 직접 생성하
                 .build();
     }
 
-    // 역직렬화 실패용 DLT(-deser)
+    @Bean
+    public NewTopic reportThresholdDLTDeser() {
+
+        return TopicBuilder.name(thresholdDltTopic + "-deser").partitions(partitions).replicas(replicas).build();
+    }
+
     @Bean
     public NewTopic volunteerPostUpdatedDLTDeser() {
 
-        return TopicBuilder.name(thresholdDltTopic + "-deser")
-                .partitions(partitions)
-                .replicas(replicas)
-                .build();
+        return TopicBuilder.name(volunteerDltTopic + "-deser").partitions(partitions).replicas(replicas).build();
     }
 }

--- a/src/main/java/com/example/emergencyassistb4b4/global/kafka/dto/ThresholdAlertEvent.java
+++ b/src/main/java/com/example/emergencyassistb4b4/global/kafka/dto/ThresholdAlertEvent.java
@@ -1,0 +1,19 @@
+package com.example.emergencyassistb4b4.global.kafka.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ThresholdAlertEvent { // window 집계 결과
+
+    private String province;
+
+    private String city;
+
+    private String alertType;  // 재난 타입
+
+    private long windowStart;  // reportedAt(epoch ms) >> KST로 날짜 산출
+
+}


### PR DESCRIPTION
## 📌 개요
이전 설계 실수로 인한 ThresholdAlertEventListener의 이벤트 받지 못하는 문제를 해결하기 위한 구조 재편성

## 🔧 주요 변경사항
- 프로듀서: report-reported에만 발행
- 스트림/프로세서: report-reported 읽어 임계치 감지 → report-threshold로 내보냄
- 컨슈머: 
   1. 즉시 알림: report-reported 소비
   2. 임계치 알림: report-threshold 소비
- DLT 각각 분리: report-reported-dlt, report-threshold-dlt

## ✅ 테스트 결과
- [v] Kafka 설정 변경 후 즉시 알림, 임계치 알림 정상 동작 확인

## 📷 시연 이미지 / 화면 캡처
-

## 📎 관련 이슈
-

## 👀 리뷰 요청
- 오늘의 리뷰어: @rabitis99 , @khg9900 , @Prototype-Km 
