### PR TITLE
Fix/redis : Redis 잔존 키 제거

### DIFF
--- a/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/controller/VolunteerPostController.java
+++ b/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/controller/VolunteerPostController.java
@@ -52,12 +52,13 @@ public class VolunteerPostController {
 
     @PreAuthorize("hasRole('NGO')")
     @GetMapping("/my")
-    public ResponseEntity<ApiResponse<Slice<PostsResponse>>> getMyPosts(
+    public ResponseEntity<ApiResponse<Slice<PostTotalResponse>>> getMyPosts(
         @AuthenticationPrincipal CustomUserDetails userDetails,
         @ModelAttribute PostFilterRequest filter,
         Pageable pageable
     ) {
-        Slice<PostsResponse> response = volunteerPostService.getMyPostList(userDetails.getUser().getId(), filter, pageable);
+        Slice<PostTotalResponse> response =
+                volunteerPostService.getMyPostList(userDetails.getUser().getId(), filter, pageable);
         return ApiResponse.onSuccess(SuccessStatus.VOLUNTEER_SUCCESS, response);
     }
 

--- a/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/infra/redis/config/TeamParticipationRedisScriptConfig.java
+++ b/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/infra/redis/config/TeamParticipationRedisScriptConfig.java
@@ -11,20 +11,25 @@ public class TeamParticipationRedisScriptConfig {
     public DefaultRedisScript<Long> joinTeamScript() {
         DefaultRedisScript<Long> script = new DefaultRedisScript<>();
         script.setScriptText("""
-            -- 정원 초과 여부 확인
-            if redis.call("SCARD", KEYS[2]) >= tonumber(ARGV[1]) then
-                return 0
+        -- 정원 초과
+        if redis.call("SCARD", KEYS[2]) >= tonumber(ARGV[1]) then return 0 end
+        -- 중복 참가
+        if redis.call("SISMEMBER", KEYS[2], ARGV[2]) == 1 then return -1 end
+
+        -- 추가
+        redis.call("SADD", KEYS[2], ARGV[2])
+        redis.call("INCR", KEYS[1])
+
+        -- 만료(둘 다)
+        if ARGV[3] then
+            local exp = tonumber(ARGV[3])
+            if exp then
+                redis.call("EXPIREAT", KEYS[1], exp)
+                redis.call("EXPIREAT", KEYS[2], exp)
             end
-            -- 중복 참가 여부 확인
-            if redis.call("SISMEMBER", KEYS[2], ARGV[2]) == 1 then
-                return -1
-            end
-            -- 유저 ID를 참가자 Set에 추가
-            redis.call("SADD", KEYS[2], ARGV[2])
-            -- 참가자 수 1 증가
-            redis.call("INCR", KEYS[1])
-            return 1
-        """);
+        end
+        return 1
+    """);
         script.setResultType(Long.class);
         return script;
     }

--- a/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/infra/redis/config/TeamParticipationRedisScriptConfig.java
+++ b/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/infra/redis/config/TeamParticipationRedisScriptConfig.java
@@ -11,24 +11,14 @@ public class TeamParticipationRedisScriptConfig {
     public DefaultRedisScript<Long> joinTeamScript() {
         DefaultRedisScript<Long> script = new DefaultRedisScript<>();
         script.setScriptText("""
-        -- 정원 초과
-        if redis.call("SCARD", KEYS[2]) >= tonumber(ARGV[1]) then return 0 end
-        -- 중복 참가
-        if redis.call("SISMEMBER", KEYS[2], ARGV[2]) == 1 then return -1 end
-
-        -- 추가
-        redis.call("SADD", KEYS[2], ARGV[2])
-        redis.call("INCR", KEYS[1])
-
-        -- 만료(둘 다)
-        if ARGV[3] then
-            local exp = tonumber(ARGV[3])
-            if exp then
-                redis.call("EXPIREAT", KEYS[1], exp)
-                redis.call("EXPIREAT", KEYS[2], exp)
-            end
-        end
-        return 1
+            -- 정원 초과
+            if redis.call("SCARD", KEYS[2]) >= tonumber(ARGV[1]) then return 0 end
+            -- 중복 참가
+            if redis.call("SISMEMBER", KEYS[2], ARGV[2]) == 1 then return -1 end
+            -- 추가
+            redis.call("SADD", KEYS[2], ARGV[2])
+            redis.call("INCR", KEYS[1])
+            return 1
     """);
         script.setResultType(Long.class);
         return script;

--- a/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/infra/redis/service/TTLRedisService.java
+++ b/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/infra/redis/service/TTLRedisService.java
@@ -1,10 +1,15 @@
 package com.example.emergencyassistb4b4.domain.volunteer.infra.redis.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -21,6 +26,7 @@ public class TTLRedisService {
      * TTL 설정 - Duration 기반
      */
     public void setTeamKeyTTL(Long postId, Long teamId, Long userId, Duration duration) {
+
         long seconds = duration.isNegative() ? 1 : duration.getSeconds(); // 최소 1초
         setTeamKeyTTL(postId, teamId, userId, seconds, TimeUnit.SECONDS);
     }
@@ -29,6 +35,7 @@ public class TTLRedisService {
      * TTL 설정 - 직접 시간 단위
      */
     public void setTeamKeyTTL(Long postId, Long teamId, Long userId, long duration, TimeUnit unit) {
+
         String countKey = String.format(COUNT_KEY_FORMAT, postId, teamId);
         String usersKey = String.format(USERS_KEY_FORMAT, postId, teamId);
 
@@ -45,6 +52,7 @@ public class TTLRedisService {
      * 팀 키 삭제
      */
     public void deleteTeamKeys(Long postId, Long teamId, Long userId) {
+
         String countKey = String.format(COUNT_KEY_FORMAT, postId, teamId);
         String usersKey = String.format(USERS_KEY_FORMAT, postId, teamId);
         redisTemplate.delete(countKey);
@@ -54,5 +62,28 @@ public class TTLRedisService {
             String duplicateKey = String.format(DUPLICATE_KEY_FORMAT, postId, teamId, userId);
             redisTemplate.delete(duplicateKey);
         }
+    }
+
+    // 팀 전체 duplicate 삭제
+    public long deleteAllDuplicateKeys(Long postId, Long teamId) {
+
+        String pattern = String.format("team:%d:%d:*:duplicate", postId, teamId);
+        ScanOptions opt = ScanOptions.scanOptions().match(pattern).count(5000).build();
+
+        List<byte[]> keys = new java.util.ArrayList<>();
+        redisTemplate.execute((RedisCallback<Void>) (RedisConnection connection) -> {
+            try (Cursor<byte[]> c = connection.keyCommands().scan(opt)) {
+                while (c.hasNext()) keys.add(c.next());
+            } catch (Exception ignore) {}
+            return null;
+        });
+
+        if (keys.isEmpty()) return 0;
+        redisTemplate.executePipelined((org.springframework.data.redis.core.RedisCallback<Object>) c -> {
+            for (byte[] k : keys) c.keyCommands().unlink(k);
+            return null;
+        });
+
+        return keys.size();
     }
 }

--- a/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/infra/redis/service/TTLRedisService.java
+++ b/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/infra/redis/service/TTLRedisService.java
@@ -86,4 +86,16 @@ public class TTLRedisService {
 
         return keys.size();
     }
+
+    // 팀 전체 키 삭제(duplicate 전체 + count/users)
+    public long deleteWholeTeamKeys(Long postId, Long teamId) {
+
+        String countKey = String.format("team:%d:%d:count", postId, teamId);
+        String usersKey = String.format("team:%d:%d:users", postId, teamId);
+
+        long dup = deleteAllDuplicateKeys(postId, teamId);
+        redisTemplate.delete(List.of(countKey, usersKey));
+
+        return dup + 2;
+    }
 }

--- a/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/infra/redis/service/TeamParticipationCleanupScheduler.java
+++ b/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/infra/redis/service/TeamParticipationCleanupScheduler.java
@@ -1,0 +1,26 @@
+package com.example.emergencyassistb4b4.domain.volunteer.infra.redis.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class TeamParticipationCleanupScheduler {
+
+    private final TaskScheduler scheduler;
+    private final TTLRedisService ttlRedisService;
+
+    public void scheduleCleanup(Long postId, Long teamId, LocalDateTime checkinEnd) {
+
+        LocalDateTime runAt = checkinEnd.plusMinutes(30);
+        scheduler.schedule(
+                () -> ttlRedisService.deleteWholeTeamKeys(postId, teamId),
+                Date.from(runAt.atZone(ZoneId.systemDefault()).toInstant())
+        );
+    }
+}

--- a/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/infra/redis/service/TeamParticipationRedisService.java
+++ b/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/infra/redis/service/TeamParticipationRedisService.java
@@ -30,7 +30,6 @@ public class TeamParticipationRedisService {
      * 참가 : 현재 인원 증가 + 중복 신청 체크 + TTL 통합 설정
      */
     public void tryJoinTeam(Long postId, Long teamId, Long userId, int maxCapacity, LocalDateTime checkinEnd) {
-
         String countKey = String.format(COUNT_KEY_FORMAT, postId, teamId);
         String usersKey = String.format(USERS_KEY_FORMAT, postId, teamId);
         String duplicateKey = String.format(DUPLICATE_KEY_FORMAT, postId, teamId, userId);
@@ -38,30 +37,25 @@ public class TeamParticipationRedisService {
         if (Boolean.TRUE.equals(redisTemplate.hasKey(duplicateKey))) {
             Boolean inUsers = redisTemplate.opsForSet().isMember(usersKey, String.valueOf(userId));
             if (Boolean.FALSE.equals(inUsers)) {
-                // 레거시 잔재. 키 삭제 후 진행
-                redisTemplate.delete(duplicateKey);
+                redisTemplate.delete(duplicateKey); // 잔재 정리 후 계속 진행
             } else {
                 throw new ApiException(ErrorStatus.VOLUNTEER_CONFLICT);
             }
         }
 
-        long expireAt = checkinEnd.plusMinutes(30).atZone(java.time.ZoneId.systemDefault()).toEpochSecond();
-
         Long result = redisTemplate.execute(
                 joinTeamScript,
                 List.of(countKey, usersKey),
                 String.valueOf(maxCapacity),
-                String.valueOf(userId),
-                String.valueOf(expireAt) // ← 추가
+                String.valueOf(userId)
         );
         if (result == null) throw new ApiException(ErrorStatus.VOLUNTEER_INTERNAL_SERVER_ERROR);
         switch (result.intValue()) {
             case 1 -> {
+                // duplicateKey에만 TTL 부여
                 Duration ttl = Duration.between(LocalDateTime.now(), checkinEnd.plusMinutes(30));
                 ttl = ttl.isNegative() ? Duration.ofSeconds(1) : ttl;
                 redisTemplate.opsForValue().set(duplicateKey, "1", ttl);
-                // (선택) 아래는 백업용. Lua에서 이미 EXPIREAT 했으므로 없어도 됨.
-                ttlRedisService.setTeamKeyTTL(postId, teamId, userId, ttl);
             }
             case 0, -1 -> throw new ApiException(ErrorStatus.VOLUNTEER_CONFLICT);
             default -> throw new ApiException(ErrorStatus.VOLUNTEER_BAD_REQUEST);
@@ -71,7 +65,7 @@ public class TeamParticipationRedisService {
     /**
      * 참가 취소 : 현재 인원 감소 + duplicateKey 삭제
      */
-    // 취소 + 필요시 키 정리만. TTL 보정 제거.
+    // 취소 + 필요시 키 정리만, TTL 보정 제거
     public void cancelJoin(Long postId, Long teamId, Long userId) {
 
         String usersKey = String.format(USERS_KEY_FORMAT, postId, teamId);
@@ -86,8 +80,7 @@ public class TeamParticipationRedisService {
         String countStr = redisTemplate.opsForValue().get(countKey);
         int currentCount = countStr != null ? Integer.parseInt(countStr) : 0;
         if (currentCount == 0) {
-            ttlRedisService.deleteTeamKeys(postId, teamId, null);
-            ttlRedisService.deleteAllDuplicateKeys(postId, teamId);
+            ttlRedisService.deleteWholeTeamKeys(postId, teamId);
         }
     }
 
@@ -120,7 +113,7 @@ public class TeamParticipationRedisService {
         // 2) 불일치 시 Redis를 DB로 맞춤
         if (dbCount != redisCount) {
             if (dbCount == 0) {
-                ttlRedisService.deleteTeamKeys(postId, teamId, null); // 완전 정리
+                ttlRedisService.deleteWholeTeamKeys(postId, teamId); // 완전 정리
             } else {
                 redisTemplate.opsForValue().set(countKey, String.valueOf(dbCount));
             }

--- a/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/infra/redis/service/TeamParticipationRedisService.java
+++ b/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/infra/redis/service/TeamParticipationRedisService.java
@@ -1,5 +1,6 @@
 package com.example.emergencyassistb4b4.domain.volunteer.infra.redis.service;
 
+import com.example.emergencyassistb4b4.domain.volunteer.repository.VolunteerParticipantRepository;
 import com.example.emergencyassistb4b4.global.exception.ApiException;
 import com.example.emergencyassistb4b4.global.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,7 @@ public class TeamParticipationRedisService {
     private final DefaultRedisScript<Long> joinTeamScript;
     private final DefaultRedisScript<Long> cancelJoinScript;
     private final TTLRedisService ttlRedisService;
+    private final VolunteerParticipantRepository participantRepository;
 
     private static final String COUNT_KEY_FORMAT = "team:%d:%d:count";           // team:{postId}:{teamId}:count
     private static final String USERS_KEY_FORMAT = "team:%d:%d:users";           // team:{postId}:{teamId}:users
@@ -28,34 +30,38 @@ public class TeamParticipationRedisService {
      * 참가 : 현재 인원 증가 + 중복 신청 체크 + TTL 통합 설정
      */
     public void tryJoinTeam(Long postId, Long teamId, Long userId, int maxCapacity, LocalDateTime checkinEnd) {
+
         String countKey = String.format(COUNT_KEY_FORMAT, postId, teamId);
         String usersKey = String.format(USERS_KEY_FORMAT, postId, teamId);
         String duplicateKey = String.format(DUPLICATE_KEY_FORMAT, postId, teamId, userId);
 
         if (Boolean.TRUE.equals(redisTemplate.hasKey(duplicateKey))) {
-            throw new ApiException(ErrorStatus.VOLUNTEER_CONFLICT);
+            Boolean inUsers = redisTemplate.opsForSet().isMember(usersKey, String.valueOf(userId));
+            if (Boolean.FALSE.equals(inUsers)) {
+                // 레거시 잔재. 키 삭제 후 진행
+                redisTemplate.delete(duplicateKey);
+            } else {
+                throw new ApiException(ErrorStatus.VOLUNTEER_CONFLICT);
+            }
         }
+
+        long expireAt = checkinEnd.plusMinutes(30).atZone(java.time.ZoneId.systemDefault()).toEpochSecond();
 
         Long result = redisTemplate.execute(
                 joinTeamScript,
                 List.of(countKey, usersKey),
                 String.valueOf(maxCapacity),
-                String.valueOf(userId)
+                String.valueOf(userId),
+                String.valueOf(expireAt) // ← 추가
         );
-
-        if (result == null) {
-            throw new ApiException(ErrorStatus.VOLUNTEER_INTERNAL_SERVER_ERROR);
-        }
-
+        if (result == null) throw new ApiException(ErrorStatus.VOLUNTEER_INTERNAL_SERVER_ERROR);
         switch (result.intValue()) {
             case 1 -> {
-                // TTL 계산: checkinEnd + 30분
                 Duration ttl = Duration.between(LocalDateTime.now(), checkinEnd.plusMinutes(30));
                 ttl = ttl.isNegative() ? Duration.ofSeconds(1) : ttl;
-
-                // 중복 키와 팀 키 TTL 동시 설정
                 redisTemplate.opsForValue().set(duplicateKey, "1", ttl);
-                ttlRedisService.setTeamKeyTTL(postId, teamId,userId,ttl);
+                // (선택) 아래는 백업용. Lua에서 이미 EXPIREAT 했으므로 없어도 됨.
+                ttlRedisService.setTeamKeyTTL(postId, teamId, userId, ttl);
             }
             case 0, -1 -> throw new ApiException(ErrorStatus.VOLUNTEER_CONFLICT);
             default -> throw new ApiException(ErrorStatus.VOLUNTEER_BAD_REQUEST);
@@ -65,28 +71,37 @@ public class TeamParticipationRedisService {
     /**
      * 참가 취소 : 현재 인원 감소 + duplicateKey 삭제
      */
+    // 취소 + 필요시 키 정리만. TTL 보정 제거.
     public void cancelJoin(Long postId, Long teamId, Long userId) {
+
         String usersKey = String.format(USERS_KEY_FORMAT, postId, teamId);
         String countKey = String.format(COUNT_KEY_FORMAT, postId, teamId);
         String duplicateKey = String.format(DUPLICATE_KEY_FORMAT, postId, teamId, userId);
 
-        Long result = redisTemplate.execute(
-                cancelJoinScript,
-                List.of(usersKey, countKey),
-                String.valueOf(userId)
-        );
-
-        if (result == null || result == -1) {
-            throw new ApiException(ErrorStatus.VOLUNTEER_BAD_REQUEST);
-        }
+        Long result = redisTemplate.execute(cancelJoinScript, List.of(usersKey, countKey), String.valueOf(userId));
+        if (result == null || result == -1) throw new ApiException(ErrorStatus.VOLUNTEER_BAD_REQUEST);
 
         redisTemplate.delete(duplicateKey);
 
-        // 취소 성공 시 중복 키 삭제
         String countStr = redisTemplate.opsForValue().get(countKey);
         int currentCount = countStr != null ? Integer.parseInt(countStr) : 0;
         if (currentCount == 0) {
             ttlRedisService.deleteTeamKeys(postId, teamId, null);
+            ttlRedisService.deleteAllDuplicateKeys(postId, teamId);
+        }
+    }
+
+    // 취소 후 TTL 보정 전담
+    public void cancelJoin(Long postId, Long teamId, Long userId, LocalDateTime checkinEnd) {
+
+        cancelJoin(postId, teamId, userId); // 위 메서드 호출
+
+        String countKey = String.format(COUNT_KEY_FORMAT, postId, teamId);
+        Long ttlSec = redisTemplate.getExpire(countKey);
+        if (ttlSec == null || ttlSec == -1) {
+            Duration ttl = Duration.between(LocalDateTime.now(), checkinEnd.plusMinutes(30));
+            long sec = ttl.isNegative() ? 1 : ttl.getSeconds();
+            ttlRedisService.setTeamKeyTTL(postId, teamId, null, sec, java.util.concurrent.TimeUnit.SECONDS);
         }
     }
 
@@ -94,8 +109,22 @@ public class TeamParticipationRedisService {
      * 현재 인원 조회
      */
     public int getCurrentCount(Long postId, Long teamId) {
+
+        // 1) DB 카운트가 정답
+        long dbCount = participantRepository.countParticipatedByTeamId(teamId);
+
         String countKey = String.format(COUNT_KEY_FORMAT, postId, teamId);
-        String count = redisTemplate.opsForValue().get(countKey);
-        return count != null ? Integer.parseInt(count) : 0;
+        String c = redisTemplate.opsForValue().get(countKey);
+        int redisCount = (c != null) ? Integer.parseInt(c) : 0;
+
+        // 2) 불일치 시 Redis를 DB로 맞춤
+        if (dbCount != redisCount) {
+            if (dbCount == 0) {
+                ttlRedisService.deleteTeamKeys(postId, teamId, null); // 완전 정리
+            } else {
+                redisTemplate.opsForValue().set(countKey, String.valueOf(dbCount));
+            }
+        }
+        return (int) dbCount;
     }
 }

--- a/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/repository/VolunteerParticipantRepository.java
+++ b/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/repository/VolunteerParticipantRepository.java
@@ -1,12 +1,10 @@
 package com.example.emergencyassistb4b4.domain.volunteer.repository;
 
 import com.example.emergencyassistb4b4.domain.volunteer.domain.VolunteerParticipant;
-import com.example.emergencyassistb4b4.domain.volunteer.enums.CheckinStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -49,4 +47,11 @@ public interface VolunteerParticipantRepository extends JpaRepository<VolunteerP
 """)
     boolean existsActiveParticipation(@Param("userId") Long userId, @Param("postId") Long postId);
 
+    @Query("""
+    select count(vp) 
+    from VolunteerParticipant vp
+    where vp.volunteerTeam.id = :teamId
+      and vp.checkinStatus = 'PARTICIPATED'
+""")
+    long countParticipatedByTeamId(@Param("teamId") Long teamId);
 }

--- a/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/repository/VolunteerTeamRepository.java
+++ b/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/repository/VolunteerTeamRepository.java
@@ -5,9 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface VolunteerTeamRepository extends JpaRepository<VolunteerTeam, Long> {
+
     Optional<VolunteerTeam> findByPost_IdAndTeamNumber(Long postId, int teamNumber);
 
     @Query("""
@@ -19,4 +22,8 @@ public interface VolunteerTeamRepository extends JpaRepository<VolunteerTeam, Lo
     WHERE VT.id = :teamId
 """)
     Optional<VolunteerTeam> findWithPostAndDetailsById(@Param("teamId") Long teamId);
+
+    // 스윕용 추가
+    @Query("select vt.id from VolunteerTeam vt where vt.id in :ids")
+    List<Long> findExistingIdsIn(@Param("ids") Collection<Long> ids);
 }

--- a/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/service/TeamParticipationSweepRunner.java
+++ b/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/service/TeamParticipationSweepRunner.java
@@ -1,0 +1,20 @@
+package com.example.emergencyassistb4b4.domain.volunteer.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TeamParticipationSweepRunner {
+
+    private final TeamParticipationSweepService sweep;
+
+    @EventListener(org.springframework.boot.context.event.ApplicationReadyEvent.class)
+    public void onReady() { sweep.sweepOnce(2000, 1000); }
+
+    @Scheduled(fixedDelay = 300_000) // 5분
+    public void periodic() { sweep.sweepOnce(5000, 1000); }
+}
+

--- a/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/service/TeamParticipationSweepService.java
+++ b/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/service/TeamParticipationSweepService.java
@@ -34,7 +34,7 @@ public class TeamParticipationSweepService {
         // 키에서 teamId 추출: 끝 토큰이 teamId 라고 가정
         Map<String, Long> keyToTeam = new HashMap<>();
         for (String k : keys) {
-            Long id = parseLastNumeric(k);
+            Long id = parseTeamId(k);
             if (id != null) keyToTeam.put(k, id);
         }
         if (keyToTeam.isEmpty()) return;
@@ -81,11 +81,13 @@ public class TeamParticipationSweepService {
 
         return out;
     }
-    private static Long parseLastNumeric(String key) {
+    private static Long parseTeamId(String key) {
 
-        int i = key.lastIndexOf(':'); if (i < 0) return null;
-        String s = key.substring(i+1);
-        for (int j=0;j<s.length();j++) if (!Character.isDigit(s.charAt(j))) return null;
+        // key 형식: team:{postId}:{teamId}(:...) → index 2가 teamId
+        String[] toks = key.split(":");
+        if (toks.length < 3) return null;
+        String s = toks[2];
+        for (int j = 0; j < s.length(); j++) if (!Character.isDigit(s.charAt(j))) return null;
         try { return Long.parseLong(s); } catch (NumberFormatException e) { return null; }
     }
 }

--- a/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/service/TeamParticipationSweepService.java
+++ b/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/service/TeamParticipationSweepService.java
@@ -1,0 +1,93 @@
+package com.example.emergencyassistb4b4.domain.volunteer.service;
+
+import com.example.emergencyassistb4b4.domain.volunteer.repository.VolunteerTeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class TeamParticipationSweepService {
+
+    private final RedisTemplate<String, Object> rt;
+    private final VolunteerTeamRepository teamRepo;
+    private static final RedisSerializer<String> STR = StringRedisSerializer.UTF_8;
+    private static final List<String> PATTERNS = List.of(
+            "team:*:*:users",
+            "team:*:*:count",
+            "team:*:*:*:duplicate"
+    );
+
+    public void sweepOnce(int scanCount, int dbBatch) {
+
+        Set<String> keys = scanAll(PATTERNS, scanCount);
+        if (keys.isEmpty()) return;
+
+        // 키에서 teamId 추출: 끝 토큰이 teamId 라고 가정
+        Map<String, Long> keyToTeam = new HashMap<>();
+        for (String k : keys) {
+            Long id = parseLastNumeric(k);
+            if (id != null) keyToTeam.put(k, id);
+        }
+        if (keyToTeam.isEmpty()) return;
+
+        // 배치로 존재 팀 조회
+        List<Long> ids = new ArrayList<>(new HashSet<>(keyToTeam.values()));
+        Set<Long> valid = new HashSet<>();
+        for (int i = 0; i < ids.size(); i += dbBatch) {
+            valid.addAll(teamRepo.findExistingIdsIn(ids.subList(i, Math.min(i+dbBatch, ids.size()))));
+        }
+        Set<Long> invalid = new HashSet<>(keyToTeam.values()); invalid.removeAll(valid);
+        if (invalid.isEmpty()) return;
+
+        List<String> del = keyToTeam.entrySet().stream()
+                .filter(e -> invalid.contains(e.getValue()))
+                .map(Map.Entry::getKey).toList();
+
+        rt.executePipelined((RedisCallback<Object>) c -> {
+            for (String k : del) c.keyCommands().unlink(STR.serialize(k));
+            return null;
+        });
+    }
+
+    private Set<String> scanAll(List<String> patterns, int count) {
+
+        Set<String> out = new HashSet<>();
+        for (String p : patterns) out.addAll(scan(p, count));
+
+        return out;
+    }
+    private Set<String> scan(String pattern, int count) {
+
+        Set<String> out = new HashSet<>();
+        ScanOptions opt = ScanOptions.scanOptions().match(pattern).count(count).build();
+
+        rt.execute((RedisConnection conn) -> {
+            Cursor<byte[]> cur = conn.keyCommands().scan(opt);
+            try { while (cur.hasNext()) {
+                String k = STR.deserialize(cur.next());
+                if (k != null) out.add(k);
+            }} finally { try { cur.close(); } catch (Exception ignore) {} }
+            return null;
+        });
+
+        return out;
+    }
+    private static Long parseLastNumeric(String key) {
+
+        int i = key.lastIndexOf(':'); if (i < 0) return null;
+        String s = key.substring(i+1);
+        for (int j=0;j<s.length();j++) if (!Character.isDigit(s.charAt(j))) return null;
+        try { return Long.parseLong(s); } catch (NumberFormatException e) { return null; }
+    }
+}
+
+

--- a/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/service/VolunteerJoinService.java
+++ b/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/service/VolunteerJoinService.java
@@ -67,14 +67,9 @@ public class VolunteerJoinService {
                 () -> teamParticipationRedisService.tryJoinTeam(
                         postId, team.getId(), userId, team.getMaxCapacity(), period.checkinEnd()
                 ),
-                () -> {
-                    // DB 저장 실패 시 Redis 롤백
-                    try {
-                        teamParticipationRedisService.cancelJoin(postId, team.getId(), userId);
-                    } catch (Exception ex) {
-                        log.error("Redis 롤백 실패 postId={}, teamId={}, userId={}", postId, team.getId(), userId, ex);
-                    }
-                }
+                () -> teamParticipationRedisService.cancelJoin(
+                        postId, team.getId(), userId, period.checkinEnd()
+                )
         );
 
         // DB 저장
@@ -99,8 +94,8 @@ public class VolunteerJoinService {
         }
 
         executeWithRetry(
-                () -> teamParticipationRedisService.cancelJoin(postId, teamId, userId),
-                null // 취소는 DB 롤백 필요 없음
+                () -> teamParticipationRedisService.cancelJoin(postId, teamId, userId, period.checkinEnd()),
+                null
         );
 
         participant.updateStatus(request.getStatus());

--- a/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/service/VolunteerJoinService.java
+++ b/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/service/VolunteerJoinService.java
@@ -6,6 +6,7 @@ import com.example.emergencyassistb4b4.domain.volunteer.dto.Join.CheckinPeriodDt
 import com.example.emergencyassistb4b4.domain.volunteer.dto.Join.CheckinStatusRequest;
 import com.example.emergencyassistb4b4.domain.volunteer.dto.Join.VolunteerParticipationResponse;
 import com.example.emergencyassistb4b4.domain.volunteer.enums.CheckinStatus;
+import com.example.emergencyassistb4b4.domain.volunteer.infra.redis.service.TeamParticipationCleanupScheduler;
 import com.example.emergencyassistb4b4.domain.volunteer.infra.redis.service.TeamParticipationRedisService;
 import com.example.emergencyassistb4b4.domain.volunteer.repository.PostRepository;
 import com.example.emergencyassistb4b4.domain.volunteer.repository.VolunteerParticipantRepository;
@@ -32,6 +33,8 @@ public class VolunteerJoinService {
     private final TeamParticipationRedisService teamParticipationRedisService;
     private final VolunteerParticipantService participantService;
     private final VolunteerParticipantRepositoryCustom volunteerParticipantRepositoryCustom;
+    private final TeamParticipationCleanupScheduler cleanupScheduler;
+
 
     @Transactional
     public void joinTeam(Long postId, int teamNumber, Long userId) {
@@ -74,6 +77,8 @@ public class VolunteerJoinService {
 
         // DB 저장
         participantService.joinSave(userId, team.getId());
+
+        cleanupScheduler.scheduleCleanup(postId, team.getId(), period.checkinEnd());
     }
 
     @Transactional

--- a/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/service/VolunteerPostService.java
+++ b/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/service/VolunteerPostService.java
@@ -6,10 +6,8 @@ import com.example.emergencyassistb4b4.domain.volunteer.domain.VolunteerParticip
 import com.example.emergencyassistb4b4.domain.volunteer.dto.Join.CheckinStatusRequest;
 import com.example.emergencyassistb4b4.domain.volunteer.dto.Post.*;
 import com.example.emergencyassistb4b4.domain.volunteer.dto.Post.common.AttendancePolicyProvider;
-import com.example.emergencyassistb4b4.domain.volunteer.enums.CheckinStatus;
 import com.example.emergencyassistb4b4.domain.volunteer.infra.redis.service.TeamParticipationRedisService;
 import com.example.emergencyassistb4b4.domain.volunteer.enums.PostStatus;
-import com.example.emergencyassistb4b4.domain.volunteer.repository.VolunteerParticipantRepository;
 import com.example.emergencyassistb4b4.global.exception.ApiException;
 import com.example.emergencyassistb4b4.global.kafka.dto.VolunteerUpdatedEvent;
 import com.example.emergencyassistb4b4.global.status.ErrorStatus;
@@ -93,11 +91,11 @@ public class VolunteerPostService {
         Slice<Post> posts = postRepository.findPosts(null, filter, pageable);
 
         return posts.map(post -> {
-            // 팀별 참여자 수 합산
-            int currentParticipants = post.getTeams().stream()
-                    .mapToInt(team -> teamParticipationRedisService.getCurrentCount(post.getId(), team.getId()))
-                    .sum();
-
+            int currentParticipants = post.getTeams().stream().mapToInt(team -> {
+                var period = postRepository.findCheckinPeriodByPostId(post.getId()).orElse(null);
+                boolean expired = period != null && LocalDateTime.now().isAfter(period.checkinEnd());
+                return expired ? 0 : teamParticipationRedisService.getCurrentCount(post.getId(), team.getId());
+            }).sum();
             return PostTotalResponse.from(post, currentParticipants);
         });
     }
@@ -113,10 +111,11 @@ public class VolunteerPostService {
         Slice<Post> posts = postRepository.findPosts(userId, filter, pageable);
 
         return posts.map(post -> {
-            int currentParticipants = post.getTeams().stream()
-                    .mapToInt(team -> teamParticipationRedisService.getCurrentCount(post.getId(), team.getId()))
-                    .sum();
-
+            int currentParticipants = post.getTeams().stream().mapToInt(team -> {
+                var period = postRepository.findCheckinPeriodByPostId(post.getId()).orElse(null);
+                boolean expired = period != null && LocalDateTime.now().isAfter(period.checkinEnd());
+                return expired ? 0 : teamParticipationRedisService.getCurrentCount(post.getId(), team.getId());
+            }).sum();
             return PostTotalResponse.from(post, currentParticipants);
         });
     }
@@ -173,16 +172,12 @@ public class VolunteerPostService {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new ApiException(ErrorStatus.VOLUNTEER_NOT_FOUND));
 
-        List<TeamStatusDto> teamStatuses = post.getTeams().stream()
-                .map(team -> {
-                    int currentCount = teamParticipationRedisService.getCurrentCount(postId,team.getId());
-                    return new TeamStatusDto(
-                            team.getId(),
-                            team.getTeamNumber(),
-                            team.getMaxCapacity(),
-                            currentCount
-                    );
-                }).toList();
+        List<TeamStatusDto> teamStatuses = post.getTeams().stream().map(team -> {
+            var period = postRepository.findCheckinPeriodByPostId(postId).orElse(null);
+            boolean expired = period != null && LocalDateTime.now().isAfter(period.checkinEnd());
+            int currentCount = expired ? 0 : teamParticipationRedisService.getCurrentCount(postId, team.getId());
+            return new TeamStatusDto(team.getId(), team.getTeamNumber(), team.getMaxCapacity(), currentCount);
+        }).toList();
 
         return new PostTeamsResponse(post.getId(), teamStatuses);
     }

--- a/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/service/VolunteerPostService.java
+++ b/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/service/VolunteerPostService.java
@@ -40,7 +40,6 @@ public class VolunteerPostService {
     private final TeamParticipationRedisService teamParticipationRedisService;
     private final VolunteerUpdatedEventProducer producer;
     private final AttendanceEventListener attendanceEventListener;
-    private final VolunteerParticipantRepository volunteerParticipantRepository;
 
     // 모집 게시글 생성
     @Transactional

--- a/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/service/VolunteerPostService.java
+++ b/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/service/VolunteerPostService.java
@@ -9,6 +9,7 @@ import com.example.emergencyassistb4b4.domain.volunteer.dto.Post.common.Attendan
 import com.example.emergencyassistb4b4.domain.volunteer.enums.CheckinStatus;
 import com.example.emergencyassistb4b4.domain.volunteer.infra.redis.service.TeamParticipationRedisService;
 import com.example.emergencyassistb4b4.domain.volunteer.enums.PostStatus;
+import com.example.emergencyassistb4b4.domain.volunteer.repository.VolunteerParticipantRepository;
 import com.example.emergencyassistb4b4.global.exception.ApiException;
 import com.example.emergencyassistb4b4.global.kafka.dto.VolunteerUpdatedEvent;
 import com.example.emergencyassistb4b4.global.status.ErrorStatus;
@@ -39,6 +40,7 @@ public class VolunteerPostService {
     private final TeamParticipationRedisService teamParticipationRedisService;
     private final VolunteerUpdatedEventProducer producer;
     private final AttendanceEventListener attendanceEventListener;
+    private final VolunteerParticipantRepository volunteerParticipantRepository;
 
     // 모집 게시글 생성
     @Transactional
@@ -103,15 +105,21 @@ public class VolunteerPostService {
 
     // 모집 게시글 다건 조회 (NGO)
     @Transactional(readOnly = true)
-    public Slice<PostsResponse> getMyPostList(Long userId, PostFilterRequest filter, Pageable pageable) {
-
+    public Slice<PostTotalResponse> getMyPostList(Long userId, PostFilterRequest filter, Pageable pageable) {
         if (filter.getVolunteerStartDate() != null && filter.getVolunteerEndDate() != null &&
                 filter.getVolunteerStartDate().isAfter(filter.getVolunteerEndDate())) {
             throw new ApiException(ErrorStatus.VOLUNTEER_BAD_REQUEST);
         }
 
-        return postRepository.findPosts(userId, filter, pageable)
-                .map(PostsResponse::from);
+        Slice<Post> posts = postRepository.findPosts(userId, filter, pageable);
+
+        return posts.map(post -> {
+            int currentParticipants = post.getTeams().stream()
+                    .mapToInt(team -> teamParticipationRedisService.getCurrentCount(post.getId(), team.getId()))
+                    .sum();
+
+            return PostTotalResponse.from(post, currentParticipants);
+        });
     }
 
 
@@ -207,7 +215,5 @@ public class VolunteerPostService {
                 .map(team -> new AttendanceStateSetEvent(team.getId(), checkinStart))
                 .forEach(attendanceEventListener::onAttendanceStateSet);
     }
-
-
 
 }

--- a/src/main/java/com/example/emergencyassistb4b4/global/config/schedulerConfig/SchedulerConfig.java
+++ b/src/main/java/com/example/emergencyassistb4b4/global/config/schedulerConfig/SchedulerConfig.java
@@ -1,0 +1,20 @@
+package com.example.emergencyassistb4b4.global.config.schedulerConfig;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class SchedulerConfig {
+
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler() {
+
+        ThreadPoolTaskScheduler t = new ThreadPoolTaskScheduler();
+        t.setPoolSize(2);
+        t.setThreadNamePrefix("cleanup-");
+
+        return t;
+    }
+}
+


### PR DESCRIPTION
## 📌 개요
앱 재기동 시 Redis 잔존 키로 인해 팀 인원 허수 카운팅 및 재신청 불가가 발생하던 문제를 구조적으로 제거

## 🔧 주요 변경사항
- Lua 스크립트 만료 보장
  - joinTeamScript에 EXPIREAT 적용 → team:{postId}:{teamId}:count/users 자동 만료
- 중복키(duplicate) 자동 정리
  - tryJoinTeam에서 team:{postId}:{teamId}:{userId}:duplicate 발견 시 SISMEMBER(users,user) 미포함이면 즉시 삭제 후 진행
- 취소 시 잔재 일괄 정리
  - cancelJoin에서 팀 인원 0이면 count/users 삭제 + deleteAllDuplicateKeys(postId,teamId)로 모든 duplicate 키 스캔·UNLINK
- 읽기 경로 DB 가드
  - getCurrentCount에서 DB 기반 또는 기간 만료 시 0 반환 + 키 정리
  - 리스트/상세 조회 시 체크인 종료 여부 선판단 후 만료면 0으로 집계
- 스윕 서비스 보강
  - SCAN(count) + 파이프라인 UNLINK와 findExistingIdsIn로 DB 배치 조회
- 레디스 TTL 보정
  - 레거시 키에 TTL 부재 시 checkinEnd+30m 기준으로 보정 적용

## ✅ 테스트 결과
- [v] 만료된 게시글의 팀 인원 항상 0 표시 확인
- [v] 동일 팀 재신청 시 duplicate 잔재로 인한 충돌 해소 확인
- [v] 취소 후 팀 인원 0일 때 모든 duplicate 키 일괄 삭제 확인
- [v] 스윕 실행 시 DB에 없는 팀 키 정상 제거 확인
- [v] 리스트/상세 화면 집계 DB 기준 일관성 확보

## 📷 시연 이미지 / 화면 캡처
-

## 📎 관련 이슈
-

## 👀 리뷰 요청
- 오늘의 리뷰어: @rabitis99 , @khg9900 , @Prototype-Km 
