### PR TITLE
출석 정책 확인

### DIFF
--- a/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/dto/Post/CreatePostRequest.java
+++ b/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/dto/Post/CreatePostRequest.java
@@ -4,6 +4,7 @@ import com.example.emergencyassistb4b4.domain.user.domain.User;
 import com.example.emergencyassistb4b4.domain.volunteer.domain.Post;
 import com.example.emergencyassistb4b4.domain.volunteer.dto.Post.common.PostAttendancePolicyDto;
 import com.example.emergencyassistb4b4.domain.volunteer.dto.Post.common.PostLocationDto;
+import com.example.emergencyassistb4b4.domain.volunteer.dto.validator.ValidAttendancePolicy;
 import com.example.emergencyassistb4b4.domain.volunteer.enums.PostCategory;
 import com.example.emergencyassistb4b4.domain.volunteer.enums.PostStatus;
 import jakarta.persistence.EnumType;
@@ -21,6 +22,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@ValidAttendancePolicy
 public class CreatePostRequest {
 
     @NotBlank(message = "제목은 필수입니다.")

--- a/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/dto/Post/UpdatePostRequest.java
+++ b/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/dto/Post/UpdatePostRequest.java
@@ -2,6 +2,7 @@ package com.example.emergencyassistb4b4.domain.volunteer.dto.Post;
 
 import com.example.emergencyassistb4b4.domain.volunteer.dto.Post.common.PostAttendancePolicyDto;
 import com.example.emergencyassistb4b4.domain.volunteer.dto.Post.common.PostLocationDto;
+import com.example.emergencyassistb4b4.domain.volunteer.dto.validator.ValidAttendancePolicy;
 import com.example.emergencyassistb4b4.domain.volunteer.enums.PostStatus;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -17,6 +18,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@ValidAttendancePolicy
 public class UpdatePostRequest {
 
     @NotBlank(message = "제목은 필수입니다.")
@@ -47,6 +49,7 @@ public class UpdatePostRequest {
     private PostLocationDto location;
 
     @Valid
+    @NotNull(message = "출석 정책은 필수입니다.")
     private PostAttendancePolicyDto attendancePolicy;
 
 }

--- a/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/dto/Post/common/PostAttendancePolicyDto.java
+++ b/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/dto/Post/common/PostAttendancePolicyDto.java
@@ -1,6 +1,7 @@
 package com.example.emergencyassistb4b4.domain.volunteer.dto.Post.common;
 
 import com.example.emergencyassistb4b4.domain.volunteer.domain.AttendancePolicy;
+import com.example.emergencyassistb4b4.domain.volunteer.dto.validator.ValidAttendancePolicy;
 import com.example.emergencyassistb4b4.global.exception.ApiException;
 import com.example.emergencyassistb4b4.global.status.ErrorStatus;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -17,6 +18,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@ValidAttendancePolicy
 public class PostAttendancePolicyDto implements AttendancePolicyProvider {
 
     @NotNull(message = "출석 시작 시간은 필수입니다.")
@@ -29,13 +31,11 @@ public class PostAttendancePolicyDto implements AttendancePolicyProvider {
     private int allowedRadiusM;
 
     @Override
-    @JsonIgnore
     public AttendancePolicy getAttendancePolicy() {
         return toEntity();
     }
 
     public AttendancePolicy toEntity() {
-        checkTime(checkinStart, checkinEnd);
         return AttendancePolicy.builder()
                 .checkinStart(checkinStart)
                 .checkinEnd(checkinEnd)
@@ -52,15 +52,4 @@ public class PostAttendancePolicyDto implements AttendancePolicyProvider {
                 .build();
     }
 
-    private static void checkTime(LocalDateTime checkinStart, LocalDateTime checkinEnd) {
-        LocalDateTime now = LocalDateTime.now();
-
-        if (checkinStart.isAfter(checkinEnd)) {
-            throw new ApiException(ErrorStatus.VOLUNTEER_BAD_REQUEST);
-        }
-
-        if (checkinEnd.isBefore(now)) {
-            throw new ApiException(ErrorStatus.VOLUNTEER_BAD_REQUEST);
-        }
-    }
 }

--- a/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/dto/validator/AttendancePolicyConstraintValidator.java
+++ b/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/dto/validator/AttendancePolicyConstraintValidator.java
@@ -1,0 +1,52 @@
+package com.example.emergencyassistb4b4.domain.volunteer.dto.validator;
+
+import com.example.emergencyassistb4b4.domain.volunteer.dto.Post.CreatePostRequest;
+import com.example.emergencyassistb4b4.domain.volunteer.dto.Post.UpdatePostRequest;
+import com.example.emergencyassistb4b4.domain.volunteer.dto.Post.common.PostAttendancePolicyDto;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.time.LocalDateTime;
+
+public class AttendancePolicyConstraintValidator
+        implements ConstraintValidator<ValidAttendancePolicy, Object> {
+
+    @Override
+    public boolean isValid(Object dto, ConstraintValidatorContext context) {
+        PostAttendancePolicyDto policy = extractPolicy(dto);
+        if (policy == null) return true;
+
+        LocalDateTime now = LocalDateTime.now();
+        boolean valid = true;
+
+        if (policy.getCheckinStart() != null && policy.getCheckinEnd() != null) {
+
+            if (policy.getCheckinStart().isAfter(policy.getCheckinEnd())) {
+                context.disableDefaultConstraintViolation();
+                context.buildConstraintViolationWithTemplate("출석 시작 시간이 종료 시간보다 늦습니다.")
+                        .addPropertyNode("attendancePolicy.checkinStart")
+                        .addConstraintViolation();
+                valid = false;
+            }
+
+            if (policy.getCheckinEnd().isBefore(now)) {
+                context.disableDefaultConstraintViolation();
+                context.buildConstraintViolationWithTemplate("출석 종료 시간이 이미 지났습니다.")
+                        .addPropertyNode("attendancePolicy.checkinEnd")
+                        .addConstraintViolation();
+                valid = false;
+            }
+        }
+
+        return valid;
+    }
+
+    private PostAttendancePolicyDto extractPolicy(Object dto) {
+        if (dto instanceof CreatePostRequest create) {
+            return create.getAttendancePolicy();
+        } else if (dto instanceof UpdatePostRequest update) {
+            return update.getAttendancePolicy();
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/dto/validator/ValidAttendancePolicy.java
+++ b/src/main/java/com/example/emergencyassistb4b4/domain/volunteer/dto/validator/ValidAttendancePolicy.java
@@ -1,0 +1,19 @@
+package com.example.emergencyassistb4b4.domain.volunteer.dto.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.*;
+
+@Target({ ElementType.TYPE }) // DTO 클래스 단위에서 검사
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = AttendancePolicyConstraintValidator.class)
+@Documented
+public @interface ValidAttendancePolicy {
+
+    String message() default "출석 정책 값이 유효하지 않습니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}
+


### PR DESCRIPTION
## 📌 개요
출석 정책 확인을 DTO 단에서 Validation 하도록 개선했습니다.  
잘못된 요청이 서비스 레이어까지 전달되는 것을 사전에 방지합니다.  

---

## 🔧 주요 변경사항
- 출석 관련 DTO에 Validation 어노테이션 추가
- 정책 위반 시 사용자 친화적인 에러 메시지 반환
- 기존 서비스/도메인 단 로직에서 중복 검증 제거 (단일 책임 유지)

---

## ✅ 테스트 결과
- [x] 정책을 위반한 요청 시 DTO Validation 에러 발생 확인
- [x] 정상 요청은 기존 로직과 동일하게 처리됨
- [x] 전체 빌드 및 단위 테스트 통과

---

## 📷 시연 이미지 / 화면 캡처
- (정책 위반 요청 시 에러 응답 예시 캡처 첨부 예정)
<img width="857" height="854" alt="백엔드 vaild" src="https://github.com/user-attachments/assets/910f3dc9-f59e-4f17-a129-789a792d948a" />

---

## 📎 관련 이슈
- Close: #36  

---

## 👀 리뷰 요청
- 오늘의 리뷰어: @Prototype-Km @classseoha @khg9900 
